### PR TITLE
Roll back to svg in PDFs

### DIFF
--- a/.github/workflows/build-upload-pdfs.yaml
+++ b/.github/workflows/build-upload-pdfs.yaml
@@ -9,42 +9,6 @@ on:
 
 jobs:
 
-  generate-kanji:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-
-      - name: Get npm cache directory path
-        id: npm-cache
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - name: Cache/Restore
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.npm-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install NPM depedencies
-        run: npm install
-
-      - name: Process KanjiVG
-        working-directory: generator
-        run: node kanjivg.js
-
-      - name: Upload Kanji diagrams for PDF generation
-        uses: actions/upload-artifact@v2
-        with:
-          name: KanjiVG_Data
-          path: generator/build
-
   generate-pdfs:
     needs: generate-kanji
     runs-on: ubuntu-latest
@@ -75,11 +39,9 @@ jobs:
       - name: Install NPM depedencies
         run: npm install
 
-      - name: Download KanjiVG data
-        uses: actions/download-artifact@v2
-        with:
-          name: KanjiVG_Data
-          path: generator/build
+      - name: Process KanjiVG
+        working-directory: generator
+        run: node kanjivg.js
 
       - name: Generate PDF files
         working-directory: generator

--- a/.github/workflows/build-upload-pdfs.yaml
+++ b/.github/workflows/build-upload-pdfs.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
 
   generate-pdfs:
-    needs: generate-kanji
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/generator/kanjivg.js
+++ b/generator/kanjivg.js
@@ -1,34 +1,29 @@
-const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const admZip = require('adm-zip');
 const optimize = require('./optimize.js');
-const sharp = require('sharp');
+const {
+    config,
+    logger,
+    ensureDirectories
+} = require('./utils.js');
 
-const KanjiVGAssetUrl = "https://github.com/KanjiVG/kanjivg/releases/download/r20160426/kanjivg-20160426-main.zip";
 const outDir = "./build";
 const zipOutputDir = path.join(outDir, 'svg');
 const svgDir = path.join(outDir, 'svg', 'kanji');
-const pngBigDir = path.join(outDir, 'png', 'kanjiBig');
-const pngSmallDir = path.join(outDir, 'png', 'kanjiSmall');
-
-const ensureDirectories = (...dirNames) => {
-    for (const dirName of dirNames) {
-        fs.existsSync(dirName) || fs.mkdirSync(dirName, {recursive: true});
-    }
-};
+const svgStrokeDir = path.join(outDir, 'png', 'kanjiStrokes');
+const svgTracesDir = path.join(outDir, 'svg', 'kanjiTracer');
 
 async function downloadAndExtract() {
-    // TODO Avoid duplications
-    const response = await fetch(KanjiVGAssetUrl);
-    const content = await response.buffer();
-    const zipOutputFile = path.join(outDir, "KanjiVG.zip");
-    await fs.writeFileSync(zipOutputFile, content);
-    const zip = admZip(zipOutputFile);
+    logger.start("Extracting KanjiVg file...");
+    const kanjiVgFile = path.join(config.srcDir, "kanjivg-20160426-main.zip");
+    const zip = admZip(kanjiVgFile);
     await zip.extractAllTo(zipOutputDir, true);
+    logger.done("KanjiVG extraction");
 }
 
 async function runCommonOptimizations() {
+    logger.start("Common optimizations");
     let filenames = await fs.readdirSync(svgDir);
     const promises = [];
     for (let filename of filenames) {
@@ -36,42 +31,34 @@ async function runCommonOptimizations() {
         promises.push(optimize.rewriteWithSvgOptimizations(filePath));
     }
     await Promise.all(promises);
+    logger.done("Common optimizations");
 }
 
-async function convertToPng() {
+async function convertToTraces() {
+    logger.start("Convert To Traces");
     let filenames = await fs.readdirSync(svgDir);
     const promises = [];
     for (let filename of filenames) {
-        const prefix = filename.split(".")[0];
         const inputFile = path.join(svgDir, filename);
-        promises.push(
-            sharp(inputFile)
-                .resize({height: 1024, width: 1024})
-                .png({quality: 100})
-                .toFile(path.join(pngBigDir, `${prefix}.png`))
-        );
-
+        const outputFile = path.join(svgTracesDir, filename);
         const content = fs.readFileSync(inputFile, {encoding: 'utf-8', flag: 'r'});
         const lines = content.split('\n')
             .filter(Boolean)
             .filter(line => !line.includes("<text transform"))
             .map(line => line.replace("stroke:#000000", "stroke:#BBBBBB"))
-            .map(line => line.replace("fill:#000000", "fill:#BBBBBB"));
-        promises.push(
-            sharp(Buffer.from(lines.join("\n")))
-                .resize({height: 512, width: 512})
-                .png({quality: 100})
-                .toFile(path.join(pngSmallDir, `${prefix}.png`))
-        );
+            .map(line => line.replace("fill:#000000", "fill:#BBBBBB"))
+            .join("\n");
+        fs.writeFileSync(outputFile, lines, {encoding: 'utf-8', flag: 'w+'})
     }
     await Promise.all(promises);
+    logger.start("Convert To Traces");
 }
 
 async function buildKanjiDiagrams() {
-    await ensureDirectories(outDir, zipOutputDir, svgDir, pngBigDir, pngSmallDir);
+    await ensureDirectories(outDir, svgDir, zipOutputDir, svgDir, svgStrokeDir, svgTracesDir);
     await downloadAndExtract();
     await runCommonOptimizations();
-    await convertToPng();
+    await convertToTraces();
 }
 
 console.time('BuildKanjiDiagrams');

--- a/generator/template/page.html
+++ b/generator/template/page.html
@@ -86,7 +86,7 @@
             background-image: url("../graphics/square_99.png");
         }
 
-        .small-square > img {
+        .small-square > object {
             height: 13mm;
             width: 13mm;
         }
@@ -126,7 +126,7 @@
         }
 
         function getKanjiImageFileName(kanji) {
-            return kanji.charCodeAt(0).toString(16).padStart(5, "0") + ".png";
+            return kanji.charCodeAt(0).toString(16).padStart(5, "0") + ".svg";
         }
     </script>
     <script id="template" type="text/x-handlebars-template">
@@ -141,10 +141,12 @@
             <tbody>
             <tr>
                 <th class="big-square" rowspan="2" colspan="2">
-                    <img src={{svgUrl}} alt={{kanji}}/>
+                    <object type="image/svg+xml" data={{svgUrl}}/>
                 </th>
                 {{#times 10 svgUrlForWriting}}
-                    <td class="small-square"><img src={{this}} alt={{kanji}}/></td>
+                    <td class="small-square">
+                        <object type="image/svg+xml" data={{this}}/>
+                    </td>
                 {{/times}}
             </tr>
             <tr>
@@ -176,7 +178,7 @@
                 const kanjiData = allData[kanji]
 
                 const extractData = function (dataObject, key) {
-                    if(dataObject !== undefined) {
+                    if (dataObject !== undefined) {
                         return (dataObject[`wk_${key}`] || dataObject[key] || ['']).map(string => string.replace(/[\^!]/, '')).join(', ')
                     } else {
                         return "";
@@ -185,8 +187,8 @@
 
                 displayData[kanji] = {
                     kanji: kanji,
-                    svgUrl: `../build/png/kanjiBig/${getKanjiImageFileName(kanji)}`,
-                    svgUrlForWriting: `../build/png/kanjiSmall/${getKanjiImageFileName(kanji)}`,
+                    svgUrl: `../build/svg/kanji/${getKanjiImageFileName(kanji)}`,
+                    svgUrlForWriting: `../build/svg/kanjiTracer/${getKanjiImageFileName(kanji)}`,
                     meaning: extractData(kanjiData, 'meanings'),
                     onyomi: extractData(kanjiData, 'readings_on'),
                     kunyomi: extractData(kanjiData, 'readings_kun')


### PR DESCRIPTION
#### Why️?

I had changed previously used SVG to PNG for faster pdf generation. But it costed slow rendering and larger file size.

#### What Changed?

- Now SVG files are used in the HTML template, instead of PNGs.
- Thanks to parallelisation of GitHub Actions and adding arguments to generator script, the build speed increased drastically, so we don’t really need to use the pngs now. (1 hour to 10 minutes)


#### Related issue

This replaces #12 
